### PR TITLE
docs: Github용 이슈 템플릿 양식 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_update.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_update.yml
@@ -1,0 +1,31 @@
+name: Documentation Update 📝
+description: 문서를 업데이트하거나 추가할 때 사용하세요.
+title: "[DOCS] 제목을 입력하세요"
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 📝 문서 업데이트 내용
+        업데이트할 문서의 내용을 설명해주세요.
+
+  - type: textarea
+    id: document-summary
+    attributes:
+      label: 📚 문서 요약
+      description: "업데이트하거나 추가할 문서의 내용을 간단히 설명해주세요."
+      placeholder: "예: README.md에 설치 가이드 추가"
+
+  - type: textarea
+    id: document-location
+    attributes:
+      label: 📄 문서 위치
+      description: "업데이트가 필요한 문서의 위치(파일명 또는 링크)를 적어주세요."
+      placeholder: "예: docs/installation.md"
+
+  - type: textarea
+    id: reason-for-update
+    attributes:
+      label: ✅ 업데이트 이유
+      description: "문서 업데이트가 필요한 이유를 설명해주세요."
+      placeholder: "예: 새로운 기능 추가로 인한 문서 보완 필요"

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,41 @@
+name: Improvement 🚀
+description: 기존 기능을 개선하거나 최적화할 때 사용하세요.
+title: "[IMPROVE] 제목을 입력하세요"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 🚀 기능 개선 요약
+        개선하고자 하는 기능을 간단히 설명해주세요.
+
+  - type: textarea
+    id: improvement-summary
+    attributes:
+      label: ✍️ 개선 내용 요약
+      description: "개선하려는 기능의 내용을 간단히 요약해주세요."
+      placeholder: "예: 페이지 로딩 속도 최적화"
+
+  - type: textarea
+    id: reason-for-improvement
+    attributes:
+      label: 🔍 개선 이유
+      description: "이 기능을 개선하려는 이유를 작성해주세요. (예: 성능 최적화, 사용자 경험 향상)"
+      placeholder: "예: 현재 로딩 속도가 느려 사용자 불만이 발생합니다."
+
+  - type: textarea
+    id: improvement-details
+    attributes:
+      label: 🛠️ 개선 작업 상세 내용
+      description: "개선할 작업의 구체적인 내용을 나열해주세요."
+      placeholder: |
+        - [ ] 코드 리팩토링
+        - [ ] 캐싱 로직 추가
+        - [ ] 데이터베이스 쿼리 최적화
+
+  - type: textarea
+    id: expected-results
+    attributes:
+      label: 📈 예상 결과
+      description: "개선 후 기대되는 결과를 설명해주세요."
+      placeholder: "예: 페이지 로딩 속도가 20% 빨라질 것으로 예상됩니다."


### PR DESCRIPTION
## 📌 목적
> Gitlab에서 Github로 옮기면서 간편한 이슈 템플릿 양식 추가가 가능하여 편의성 도모

## 🛠️ 작업 상세 내용
- [x] 기능 개선 템플릿 추가
- [x] 문서 업데이트 템플릿 추가

## 🔍 변경 사항
- 기능 개선 템플릿 추가
- 문서 업데이트 템플릿 추가